### PR TITLE
Set an initial area code in the install method of the Customer data type

### DIFF
--- a/Model/DataTypes/Customers.php
+++ b/Model/DataTypes/Customers.php
@@ -161,6 +161,11 @@ class Customers
     // phpcs:ignore Generic.Metrics.NestingLevel.TooHigh,Magento2.Annotation.MethodArguments.NoCommentBlock
     public function install(array $rows, array $header, string $modulePath, array $settings)
     {
+        try {
+            $this->appState->setAreaCode(AppArea::AREA_ADMINHTML);
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            $this->helper->logMessage('Area code was already set: ' . $e->getMessage())
+        }
 
         $this->settings = $settings;
 


### PR DESCRIPTION
When trying to import B2C customers via either customers.csv or customers.json on a 2.4.7 build, an "Area not set" code was consistently thrown and the customers were not imported.  To address, I set the area to AREA_ADMINHTML at the start of the install method via a try-catch which solved the issue.  Not sure if that's the right way to handle it, but wanted to try to help...