### PR TITLE
catch the error if command not available instead of breaking the installation

### DIFF
--- a/Observer/DeployStaticContent.php
+++ b/Observer/DeployStaticContent.php
@@ -58,8 +58,12 @@ class DeployStaticContent implements ObserverInterface
     private function deployContent()
     {
         $cmd = $this->functionCallPath . 'setup:static-content:deploy -f';
+        try {
         $execOutput = $this->shell->execute($cmd);
         $this->helper->logMessage($execOutput, "info");
+        } catch (\Exception $exception) {
+            $this->helper->logMessage($exception->getMessage(), "error");
+        }
     }
 
     /**
@@ -70,7 +74,11 @@ class DeployStaticContent implements ObserverInterface
     private function flushCache()
     {
         $cmd = $this->functionCallPath . 'cache:flush';
-        $execOutput = $this->shell->execute($cmd);
-        $this->helper->logMessage($execOutput, "info");
+        try {
+            $execOutput = $this->shell->execute($cmd);
+            $this->helper->logMessage($execOutput, "info");
+        } catch (\Exception $exception) {
+            $this->helper->logMessage($exception->getMessage(), "error");
+        }
     }
 }


### PR DESCRIPTION
During the Commerce installation, the cache flush command is not found if a fixture file is imported.
To address this I've added a catch block to show this error in logs instead of breaking the installation process.