### PR TITLE
Area code not set issue fixed

### DIFF
--- a/Model/DataTypes/Customers.php
+++ b/Model/DataTypes/Customers.php
@@ -360,13 +360,31 @@ class Customers
                 //try to load with the given website id. Then fail back to null (website id 1)
                 //in case the customer was loaded outside of the current data load
                 try {
-                    $customer = $this->customerRepositoryInterface->get(
+                    /* 2.4.8 fix area code not set */
+                    $customer = $this->appState->emulateAreaCode(
+                        AppArea::AREA_ADMINHTML,
+                        [$this->customerRepositoryInterface, 'get'],
+                        [
+                            $rewardCustomer['email'],
+                            $this->stores->getWebsiteId($rewardCustomer['_website'])
+                        ]
+                    );
+
+                    /*$customer = $this->customerRepositoryInterface->get(
                         $rewardCustomer['email'],
                         $this->stores->getWebsiteId($rewardCustomer['_website'])
-                    );
+                    );*/
                 } catch (NoSuchEntityException $e) {
                     try {
-                        $customer = $this->customerRepositoryInterface->get($rewardCustomer['email']);
+                        $customer = $this->appState->emulateAreaCode(
+                            AppArea::AREA_ADMINHTML,
+                            [$this->customerRepositoryInterface, 'get'],
+                            [
+                                $rewardCustomer['email']
+                            ]
+                        );
+
+                        /*$customer = $this->customerRepositoryInterface->get($rewardCustomer['email']);*/
                     } catch (NoSuchEntityException $e) {
                         $this->helper->logMessage("Rewards points cannot be added to customer: "
                         .$e->getMessage(), "warning");

--- a/Model/DataTypes/Customers.php
+++ b/Model/DataTypes/Customers.php
@@ -202,10 +202,19 @@ class Customers
        
         foreach ($cleanCustomerArray as $row) {
             try {
-                $customer = $this->customerRepositoryInterface->get(
+                /* 2.4.8 fix area code not set */
+                $customer = $this->appState->emulateAreaCode(
+                    AppArea::AREA_ADMINHTML,
+                    [$this->customerRepositoryInterface, 'get'],
+                    [
+                        $row['email'],
+                        $this->stores->getWebsiteId($row['_website'])
+                    ]
+                );
+                /*$customer = $this->customerRepositoryInterface->get(
                     $row['email'],
                     $this->stores->getWebsiteId($row['_website'])
-                );
+                );*/
 
                 if (!empty($row['store_view_code'])) {
                     $customer->setCreatedIn($this->stores->getViewName($row['store_view_code']));

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magentoese/module-data-install",
     "type": "magento2-module",
-    "version" : "2.6.0",
+    "version" : "2.6.1",
     "autoload": {
         "files": [ "registration.php" ],
         "psr-4": {


### PR DESCRIPTION
Area code not set issue thrown when fetching customer using `customerRepositoryInterface`.
Fixed by adding the `emulateAreaCode`

Tested for commerce versions -

1. 2.4.8
2. 2.4.7

Datapack verified - 
1. Auto
2. Venia
3. Citisignal